### PR TITLE
Refactor the VPN models

### DIFF
--- a/src/databases/dynamodb.py
+++ b/src/databases/dynamodb.py
@@ -2,7 +2,7 @@ import boto3
 from typing import Optional
 
 from pydantic import BaseModel
-from models.vpn import VpnModel, WireguardRequestModel
+from models.vpn import WireguardModel, VpnModel
 from models.peers import PeerDbModel
 from models.connection import ConnectionType
 from vpn_manager.vpn import VpnServer
@@ -69,7 +69,7 @@ class DynamoDb(InMemoryDataStore):
             vpn = VpnModel(
                 name=dynamo_vpn["name"],
                 description=dynamo_vpn["description"],
-                wireguard=WireguardRequestModel(
+                wireguard=WireguardModel(
                     ip_address=dynamo_vpn["wireguard_ip_address"],
                     address_space=dynamo_vpn["wireguard_subnet"],
                     interface=dynamo_vpn["wireguard_interface"],

--- a/src/databases/in_mem_db.py
+++ b/src/databases/in_mem_db.py
@@ -1,5 +1,5 @@
 from databases.interface import AbstractDatabase
-from models.vpn import VpnModel, WireguardRequestModel
+from models.vpn import WireguardModel, VpnModel
 from models.peers import PeerDbModel
 from models.connection import ConnectionModel, ConnectionType
 from vpn_manager.vpn import VpnServer
@@ -46,7 +46,7 @@ class InMemoryDataStore(AbstractDatabase):
         self._vpn_networks[new_vpn.name] = VpnModel(
             name=new_vpn.name,
             description=new_vpn.description,
-            wireguard=WireguardRequestModel(
+            wireguard=WireguardModel(
                 ip_address=new_vpn.ip_address,
                 address_space=new_vpn.address_space,
                 interface=new_vpn.interface,

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, PrivateAttr
+
+
+class OpaqueModel(BaseModel):
+    """
+    This is a shared model for anything that uses SecretStr.  It can be used to automate whether the secret is visible.
+    """
+
+    _opaque: bool = PrivateAttr(default=True)
+
+    @property
+    def opaque(self):
+        return self._opaque
+
+    @opaque.setter
+    def opaque(self, value: bool) -> None:
+        # here you can implement custom logic, like propagating to children models for example (my case)
+        self._opaque = value

--- a/src/models/connection.py
+++ b/src/models/connection.py
@@ -1,7 +1,6 @@
 from pydantic import BaseModel
 from enum import Enum
-from typing import Any
-from models.ssh import SshConnectionModel
+from models.ssh import SshConnectionModel, SshConnectionResponseModel
 
 """
 This module contains pydantic modules for how the wireguard manager should manage (add/remove peers) from the 
@@ -21,7 +20,16 @@ class ConnectionModel(BaseModel):
     """
 
     type: ConnectionType
-    data: SshConnectionModel | Any
+    data: SshConnectionModel
+
+
+class ConnectionResponseModel(BaseModel):
+    """
+    This model includes all the information required to connect to the wireguard server.  The data field is generic.
+    """
+
+    type: ConnectionType
+    data: SshConnectionResponseModel
 
 
 def build_connection_model(connection_info: dict | None) -> ConnectionModel | None:

--- a/src/models/ssh.py
+++ b/src/models/ssh.py
@@ -1,24 +1,18 @@
-from pydantic import BaseModel, Field, SecretStr, PrivateAttr, field_serializer, model_serializer
-from typing import Optional, List
+from pydantic import BaseModel, Field, SecretStr, field_serializer
+from typing import Optional
+from models import OpaqueModel
 
 
 # Models for the SSH class
 class SshConnectionModel(BaseModel):
-    _opaque: bool = PrivateAttr(default=True)
-
     ip_address: str = Field(..., description="The IP address SSH will use to connect to the VPN server")
     username: str = Field(..., description="The SSH username")
+    key: str = Field(..., description="The SSH private key")
+    key_password: Optional[str] = Field(None, description="The password for the SSH private key")
+
+
+class SshConnectionResponseModel(SshConnectionModel, OpaqueModel):
     key: SecretStr = Field(..., description="The SSH private key")
-    key_password: Optional[SecretStr] = Field(None, description="The password for the SSH private key")
-
-    @property
-    def opaque(self):
-        return self._opaque
-
-    @opaque.setter
-    def opaque(self, value: bool) -> None:
-        # here you can implement custom logic, like propagating to children models for example (my case)
-        self._opaque = value
 
     @field_serializer("key")
     @field_serializer("key_password")

--- a/src/models/vpn.py
+++ b/src/models/vpn.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel, Field, SecretStr, PrivateAttr, field_serializer
-from typing import Optional, List
-from models.connection import ConnectionModel
+from pydantic import BaseModel, Field, SecretStr, field_serializer
+from typing import Optional
+from models.connection import ConnectionModel, ConnectionResponseModel
+from models import OpaqueModel
 
 
 class VpnMetaData(BaseModel):
@@ -8,37 +9,17 @@ class VpnMetaData(BaseModel):
     description: Optional[str] = Field(..., description="A description of the wireguard VPN")
 
 
-# -----------------------------------------------------------
-# API Request Models
-class WireguardRequestModel(BaseModel):
-    _opaque: bool = PrivateAttr(default=True)
-
+class WireguardModel(BaseModel):
     ip_address: str = Field(..., description="The wireguard IP address")
     address_space: str = Field(..., description="The subnet for the wireguard VPN. E.g. 10.0.0.0/16")
     interface: str = Field(..., description="The wireguard interface name")
     public_key: str = Field(..., description="The wireguard public key")
-    private_key: SecretStr = Field(..., description="The wireguard private key")
+    private_key: str = Field(..., description="The wireguard private key")
     listen_port: int = Field(..., description="The wireguard listen port")
 
-    @property
-    def opaque(self):
-        return self._opaque
 
-    @opaque.setter
-    def opaque(self, value: bool) -> None:
-        # here you can implement custom logic, like propagating to children models for example (my case)
-        self._opaque = value
-
-    @field_serializer("private_key", when_used="json")
-    def dump_secret_json(self, secret: SecretStr):
-        if self._opaque:
-            return secret
-        else:
-            return secret.get_secret_value() if secret is not None else None
-
-
-class VpnPutRequestModel(BaseModel):
-    wireguard: WireguardRequestModel = Field(
+class VpnPutModel(BaseModel):
+    wireguard: WireguardModel = Field(
         ..., description="This contains all the wireguard configuration for the VPN server"
     )
     connection_info: Optional[ConnectionModel] = Field(
@@ -49,8 +30,32 @@ class VpnPutRequestModel(BaseModel):
 
 
 # -----------------------------------------------------------
+# API Response Models
+class WireguardResponseModel(WireguardModel, OpaqueModel):
+    private_key: SecretStr = Field(..., description="The wireguard private key")
+
+    @field_serializer("private_key", when_used="json")
+    def dump_secret_json(self, secret: SecretStr):
+        if self._opaque:
+            return secret
+        else:
+            return secret.get_secret_value() if secret is not None else None
+
+
+class VpnPutResponseModel(BaseModel):
+    wireguard: WireguardResponseModel = Field(
+        ..., description="This contains all the wireguard configuration for the VPN server"
+    )
+    connection_info: Optional[ConnectionResponseModel] = Field(
+        None,
+        description="This contains all the information required for this service to manage the VPN server. If "
+        "provided, this service will add and remove peers from the VPN server itself.",
+    )
+
+
+# -----------------------------------------------------------
 # Database Models
-class VpnModel(VpnPutRequestModel, VpnMetaData):
+class VpnResponseModel(VpnPutResponseModel, VpnMetaData):
     @property
     def opaque(self):
         return self.wireguard.opaque
@@ -60,3 +65,7 @@ class VpnModel(VpnPutRequestModel, VpnMetaData):
         self.wireguard.opaque = value
         if self.connection_info is not None:
             self.connection_info.data.opaque = value
+
+
+class VpnModel(VpnPutModel, VpnMetaData):
+    pass

--- a/src/server_manager/ssh.py
+++ b/src/server_manager/ssh.py
@@ -36,9 +36,7 @@ class SshConnection(AbstractServerManager):
             ssh.connect(
                 ssh_connection_info.ip_address,
                 username=ssh_connection_info.username,
-                pkey=paramiko.RSAKey.from_private_key(
-                    StringIO(ssh_connection_info.key.get_secret_value()), password=key_password
-                ),
+                pkey=paramiko.RSAKey.from_private_key(StringIO(ssh_connection_info.key), password=key_password),
             )
             ssh_stdin, ssh_stdout, ssh_stderr = ssh.exec_command(cmd, timeout=10)
             # TODO: Add support for other corner-cases

--- a/src/vpn_manager/__init__.py
+++ b/src/vpn_manager/__init__.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 from databases.interface import AbstractDatabase
 from vpn_manager.vpn import VpnServer
 from vpn_manager.peers import PeerList, Peer
-from models.vpn import VpnPutRequestModel
+from models.vpn import VpnPutModel
 from server_manager import server_manager_factory
 
 log = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ class VpnManager:
     def __init__(self, db_manager: AbstractDatabase):
         self._db_manager = db_manager
 
-    def add_vpn(self, name: str, description: str, vpn_request: VpnPutRequestModel):
+    def add_vpn(self, name: str, description: str, vpn_request: VpnPutModel):
         _vpn = self.get_vpn(name)
         if _vpn is not None:
             raise ValueError(f"VPN with name {name} already exists.")
@@ -54,7 +54,7 @@ class VpnManager:
             address_space=vpn_request.wireguard.address_space,
             interface=vpn_request.wireguard.interface,
             public_key=vpn_request.wireguard.public_key,
-            private_key=vpn_request.wireguard.private_key.get_secret_value(),
+            private_key=vpn_request.wireguard.private_key,
             listen_port=vpn_request.wireguard.listen_port,
             connection_info=vpn_request.connection_info,
             peers=PeerList(name, self._db_manager),

--- a/src/vpn_manager/vpn.py
+++ b/src/vpn_manager/vpn.py
@@ -1,6 +1,6 @@
 from typing import Optional
 import ipaddress
-from models.vpn import VpnModel, WireguardRequestModel
+from models.vpn import WireguardModel, VpnModel
 from models.connection import ConnectionModel
 from models.peers import PeerModel
 from vpn_manager.peers import PeerList
@@ -138,7 +138,7 @@ class VpnServer:
         return VpnModel(
             name=self.name,
             description=self._description,
-            wireguard=WireguardRequestModel(
+            wireguard=WireguardModel(
                 ip_address=self.ip_address,
                 address_space=self.address_space,
                 interface=self.interface,


### PR DESCRIPTION
* This is a code cleanup.
* Distinguish between the objects we are returning as part of the Request from those that are used internally.
* Things are also simpler if we only time we deal with SecretStr is when we return an object after a GET request.  
* The models are more organized and concise.  I split out the OpaqueModel into it's own thing that can be inherited.