### PR TITLE
Refactor peer models

### DIFF
--- a/src/databases/interface.py
+++ b/src/databases/interface.py
@@ -3,7 +3,7 @@ import abc
 import typing
 
 if typing.TYPE_CHECKING:
-    from models.peers import PeerModel
+    from models.peers import PeerDbModel
     from vpn_manager.vpn import VpnServer
     from vpn_manager.peers import Peer
     from models.connection import ConnectionModel
@@ -36,12 +36,12 @@ class AbstractDatabase(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def add_peer(self, vpn_name: str, peer: PeerModel):
+    def add_peer(self, vpn_name: str, peer: PeerDbModel):
         """Add a new peer to the database.  If it already exists, raise a ValueError exception."""
         pass
 
     @abc.abstractmethod
-    def delete_peer(self, vpn_name: str, peer: PeerModel):
+    def delete_peer(self, vpn_name: str, peer: PeerDbModel):
         """Remove a peer from the database."""
         pass
 

--- a/src/interfaces/peers.py
+++ b/src/interfaces/peers.py
@@ -2,7 +2,7 @@ from fastapi import Response, HTTPException
 from fastapi.responses import PlainTextResponse
 from uuid import uuid4
 from http import HTTPStatus
-from models.peers import PeerModel, PeerRequestModel
+from models.peers import PeerResponseModel, PeerRequestModel
 from vpn_manager.peers import Peer
 import logging
 from interfaces.custom_router import WgAPIRouter
@@ -28,7 +28,7 @@ def validate_peer_exists(vpn_name: str, ip_address: str, vpn_manager) -> None:
         )
 
 
-@peer_router.get("/vpn/{vpn_name}/peers", tags=["peers"], response_model=list[PeerModel])
+@peer_router.get("/vpn/{vpn_name}/peers", tags=["peers"], response_model=list[PeerResponseModel])
 def get_peers(vpn_name: str, hide_secrets: bool = True) -> Response:
     """Get all the peers for a given VPN."""
     vpn_manager = peer_router.vpn_manager
@@ -40,8 +40,8 @@ def get_peers(vpn_name: str, hide_secrets: bool = True) -> Response:
     return peer_models
 
 
-@peer_router.post("/vpn/{vpn_name}/peer", tags=["peers"], response_model=PeerModel)
-def add_peer(vpn_name: str, peer: PeerRequestModel) -> PeerModel:
+@peer_router.post("/vpn/{vpn_name}/peer", tags=["peers"], response_model=PeerResponseModel)
+def add_peer(vpn_name: str, peer: PeerRequestModel) -> PeerResponseModel:
     """Add a new peer to a VPN."""
     vpn_manager = peer_router.vpn_manager
     validate_vpn_exists(vpn_name, vpn_manager)
@@ -107,7 +107,7 @@ def add_peer(vpn_name: str, peer: PeerRequestModel) -> PeerModel:
     return new_peer.to_model()
 
 
-@peer_router.delete("/vpn/{vpn_name}/peer/{ip_address}", tags=["peers"], response_model=PeerModel)
+@peer_router.delete("/vpn/{vpn_name}/peer/{ip_address}", tags=["peers"])
 def delete_peer(vpn_name: str, ip_address: str) -> Response:
     """Delete a peer from a VPN."""
     vpn_manager = peer_router.vpn_manager
@@ -126,8 +126,8 @@ def delete_peer(vpn_name: str, ip_address: str) -> Response:
     return Response(status_code=HTTPStatus.OK)
 
 
-@peer_router.get("/vpn/{vpn_name}/peer/{ip_address}", tags=["peers"], response_model=PeerModel)
-def get_peer(vpn_name: str, ip_address: str, hide_secrets: bool = True) -> PeerModel:
+@peer_router.get("/vpn/{vpn_name}/peer/{ip_address}", tags=["peers"], response_model=PeerResponseModel)
+def get_peer(vpn_name: str, ip_address: str, hide_secrets: bool = True) -> PeerResponseModel:
     """Return the peer with the given IP address on a given VPN."""
     vpn_manager = peer_router.vpn_manager
     validate_peer_exists(vpn_name, ip_address, vpn_manager)
@@ -156,8 +156,8 @@ PersistentKeepalive = {peer.persistent_keepalive}"""
     return response
 
 
-@peer_router.get("/vpn/{vpn_name}/peer/tag/{tag}", tags=["peers"], response_model=list[PeerModel])
-def get_peer_by_tag(vpn_name: str, tag: str, hide_secrets: bool = True) -> list[PeerModel]:
+@peer_router.get("/vpn/{vpn_name}/peer/tag/{tag}", tags=["peers"], response_model=list[PeerResponseModel])
+def get_peer_by_tag(vpn_name: str, tag: str, hide_secrets: bool = True) -> list[PeerResponseModel]:
     """Return the peers with the given tag on a given VPN."""
     vpn_manager = peer_router.vpn_manager
     validate_vpn_exists(vpn_name, vpn_manager)
@@ -169,9 +169,9 @@ def get_peer_by_tag(vpn_name: str, tag: str, hide_secrets: bool = True) -> list[
 
 
 @peer_router.post(
-    "/vpn/{vpn_name}/peers/{ip_address}/generate-wireguard-keys", tags=["peers"], response_model=PeerModel
+    "/vpn/{vpn_name}/peers/{ip_address}/generate-wireguard-keys", tags=["peers"], response_model=PeerResponseModel
 )
-def generate_new_wireguard_keys(vpn_name: str, ip_address: str) -> PeerModel:
+def generate_new_wireguard_keys(vpn_name: str, ip_address: str) -> PeerResponseModel:
     """Generate new WireGuard keys for a peer."""
     server_manager = None
     vpn_manager = peer_router.vpn_manager
@@ -195,8 +195,8 @@ def generate_new_wireguard_keys(vpn_name: str, ip_address: str) -> PeerModel:
     return peer.to_model()
 
 
-@peer_router.post("/vpn/{vpn_name}/import", tags=["peers"], response_model=list[PeerModel])
-def import_vpn_peers(vpn_name: str) -> list[PeerModel]:
+@peer_router.post("/vpn/{vpn_name}/import", tags=["peers"], response_model=list[PeerResponseModel])
+def import_vpn_peers(vpn_name: str) -> list[PeerResponseModel]:
     """This imports peers from the WireGuard VPN into this service."""
     vpn_manager = peer_router.vpn_manager
     validate_vpn_exists(vpn_name, vpn_manager)
@@ -215,8 +215,8 @@ def import_vpn_peers(vpn_name: str) -> list[PeerModel]:
     return [peer.to_model() for peer in added_peers]
 
 
-@peer_router.put("/vpn/{vpn_name}/peer/{ip_address}/tag/{tag}", tags=["peers"], response_model=PeerModel)
-def add_tag_to_peer(vpn_name: str, ip_address: str, tag: str) -> PeerModel:
+@peer_router.put("/vpn/{vpn_name}/peer/{ip_address}/tag/{tag}", tags=["peers"], response_model=PeerResponseModel)
+def add_tag_to_peer(vpn_name: str, ip_address: str, tag: str) -> PeerResponseModel:
     """Add a tag to a peer."""
     vpn_manager = peer_router.vpn_manager
     validate_peer_exists(vpn_name, ip_address, vpn_manager)
@@ -224,8 +224,8 @@ def add_tag_to_peer(vpn_name: str, ip_address: str, tag: str) -> PeerModel:
     return vpn_manager.get_peers_by_ip(vpn_name=vpn_name, ip_address=ip_address).to_model()
 
 
-@peer_router.delete("/vpn/{vpn_name}/peer/{ip_address}/tag/{tag}", tags=["peers"], response_model=PeerModel)
-def delete_tag_from_peer(vpn_name: str, ip_address: str, tag: str) -> PeerModel:
+@peer_router.delete("/vpn/{vpn_name}/peer/{ip_address}/tag/{tag}", tags=["peers"], response_model=PeerResponseModel)
+def delete_tag_from_peer(vpn_name: str, ip_address: str, tag: str) -> PeerResponseModel:
     """Remove a tag from a peer."""
     vpn_manager = peer_router.vpn_manager
     validate_peer_exists(vpn_name, ip_address, vpn_manager)

--- a/src/interfaces/vpn.py
+++ b/src/interfaces/vpn.py
@@ -7,7 +7,7 @@ from setuptools.windows_support import hide_file
 from interfaces.custom_router import WgAPIRouter
 from models.vpn import VpnResponseModel, VpnPutModel
 from models.connection import build_connection_model, ConnectionModel
-from models.peers import PeerModel
+from models.peers import PeerResponseModel
 from vpn_manager import VpnUpdateException
 from server_manager import ConnectionException
 import logging
@@ -60,7 +60,7 @@ def add_vpn(name: str, vpn: VpnPutModel, description: Optional[str] = "") -> Res
 
 
 @vpn_router.put("/vpn/{name}/connection-info", tags=["vpn"])
-def update_ssh(name: str, connection_info: ConnectionModel) -> list[PeerModel]:
+def update_ssh(name: str, connection_info: ConnectionModel) -> list[PeerResponseModel]:
     """
     Update the SSH connection information for a VPN server.  This is used to connect to the VPN server to add and
     remove peers.  This will automatically sync peers on the wireguard server into the wireguard manager.

--- a/src/models/peers.py
+++ b/src/models/peers.py
@@ -5,41 +5,24 @@ from typing import Optional
 # -----------------------------------------------------------
 # API Request Models
 class PeerRequestModel(BaseModel):
-    _opaque: bool = PrivateAttr(default=True)
-
     ip_address: Optional[str] = Field(
         None,
         description="The wireguard IP address of the peer.  If not provided, the next available IP on the VPN will be used.",
     )
     allowed_ips: str = Field(..., description="This defines the IPs that are allowed ")
-    public_key: Optional[str] = Field(
+    public_key: str | None = Field(
         None,
-        description="The public wireguard key for the peer.  I this is not provide the key-pair will be auto generated.",
+        description="The public wireguard key for the peer.  If this is not provide the key-pair will be auto "
+        "generated.",
     )
-    private_key: Optional[SecretStr] = Field(None, description="The private wireguard key for the peer.")
+    private_key: str | None = Field(None, description="The private wireguard key for the peer.")
     persistent_keepalive: int = Field(..., description="The wireguard keep-alive configuration for the peer.")
     tags: list[str] = Field(..., description="Tags associated with the wireguard peer.")
-
-    @property
-    def opaque(self):
-        return self._opaque
-
-    @opaque.setter
-    def opaque(self, value: bool) -> None:
-        # here you can implement custom logic, like propagating to children models for example (my case)
-        self._opaque = value
-
-    @field_serializer("private_key", when_used="json")
-    def dump_secret_json(self, secret: SecretStr):
-        if self._opaque:
-            return secret
-        else:
-            return secret.get_secret_value() if secret is not None else None
 
 
 # -----------------------------------------------------------
 # Database Models
-class PeerModel(BaseModel):
+class PeerResponseModel(BaseModel):
     _opaque: bool = PrivateAttr(default=True)
 
     ip_address: str = Field(..., description="The wireguard IP address of the peer")
@@ -66,5 +49,5 @@ class PeerModel(BaseModel):
             return secret.get_secret_value() if secret is not None else None
 
 
-class PeerDbModel(PeerModel):
+class PeerDbModel(PeerRequestModel):
     peer_id: str = Field(..., description="This is the unique database ID for the peer.")

--- a/src/vpn_manager/peers.py
+++ b/src/vpn_manager/peers.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from databases.interface import AbstractDatabase
-from models.peers import PeerModel, PeerDbModel
+from models.peers import PeerResponseModel, PeerDbModel
 
 
 class Peer:
@@ -58,8 +58,8 @@ class Peer:
     def tags(self) -> list[str]:
         return self._tags
 
-    def to_model(self) -> PeerModel:
-        return PeerModel(
+    def to_model(self) -> PeerResponseModel:
+        return PeerResponseModel(
             ip_address=self._ip_address,
             allowed_ips=self._allowed_ips,
             public_key=self._public_key,
@@ -107,6 +107,6 @@ class PeerList(list):
             self.db_interface.delete_peer(vpn_name=self.vpn_name, peer=peer.to_db_model())
         super().clear()
 
-    def to_model(self) -> list[PeerModel]:
-        """Convert the peer list to a list of PeerModel."""
+    def to_model(self) -> list[PeerResponseModel]:
+        """Convert the peer list to a list of PeerResponseModel."""
         return [peer.to_model() for peer in self]

--- a/src/vpn_manager/vpn.py
+++ b/src/vpn_manager/vpn.py
@@ -2,7 +2,7 @@ from typing import Optional
 import ipaddress
 from models.vpn import WireguardModel, VpnModel
 from models.connection import ConnectionModel
-from models.peers import PeerModel
+from vpn_manager.peers import Peer
 from vpn_manager.peers import PeerList
 from databases.interface import AbstractDatabase
 from server_manager import server_manager_factory
@@ -19,7 +19,7 @@ class VpnServer:
         public_key: str,
         listen_port: int,
         connection_info: ConnectionModel,
-        peers: PeerList,
+        peers: PeerList[Peer],
         description: Optional[str] = None,
         private_key: Optional[str] = None,
     ):
@@ -33,7 +33,7 @@ class VpnServer:
         self._private_key = private_key
         self._listen_port = listen_port
         self._connection_info = connection_info
-        self._peers = peers
+        self._peers: PeerList[Peer] = peers
 
         # Get a list of all IPs for this subnet
         self._all_ip_addresses = set(ipaddress.ip_network(self.address_space).hosts())
@@ -99,7 +99,7 @@ class VpnServer:
         self._database.update_connection_info(self.name, connection_info)
 
     @property
-    def peers(self) -> list[PeerModel]:
+    def peers(self) -> PeerList[Peer]:
         return self._peers
 
     @property


### PR DESCRIPTION
This is a minor refactor of the peer pydantic models.  
* Rename them to distinguish between the one we should use for accepting a request and one to use when returning a response.
* Only the response needs to use SecretStr.  We don't have any need to be opaque for the request.