### PR TITLE
Add support for storing and querying peer history

### DIFF
--- a/serverless-v3/serverless.yml
+++ b/serverless-v3/serverless.yml
@@ -75,6 +75,41 @@ resources:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
         TableName: wireguard-manager-peers-${self:provider.stage}
+    WireguardManagerPeersHistoryTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: wireguard-manager-peers-history-${self:provider.stage}
+        AttributeDefinitions:
+          - AttributeName: peer_history_id
+            AttributeType: S
+          - AttributeName: timestamp
+            AttributeType: N
+          - AttributeName: vpn_name_ip_addr
+            AttributeType: S
+          - AttributeName: vpn_name_tag
+            AttributeType: S
+        KeySchema:
+          - AttributeName: peer_history_id
+            KeyType: HASH
+          - AttributeName: timestamp
+            KeyType: RANGE
+        GlobalSecondaryIndexes:
+          - IndexName: GSI-byIp
+            KeySchema:
+              - AttributeName: vpn_name_ip_addr
+                KeyType: HASH
+              - AttributeName: timestamp
+                KeyType: RANGE
+            Projection:
+              ProjectionType: ALL
+          - IndexName: GSI-byTag
+            KeySchema:
+              - AttributeName: vpn_name_tag
+                KeyType: HASH
+              - AttributeName: timestamp
+                KeyType: RANGE
+            Projection:
+              ProjectionType: ALL
 configValidationMode: error
 plugins:
   - serverless-dynamodb

--- a/serverless-v4/serverless.yml
+++ b/serverless-v4/serverless.yml
@@ -75,6 +75,41 @@ resources: # CloudFormation template syntax
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
         TableName: wireguard-manager-peers-${self:provider.stage}
+    WireguardManagerPeersHistoryTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: wireguard-manager-peers-history-${self:provider.stage}
+        AttributeDefinitions:
+          - AttributeName: peer_history_id
+            AttributeType: S
+          - AttributeName: timestamp
+            AttributeType: N
+          - AttributeName: vpn_name_ip_addr
+            AttributeType: S
+          - AttributeName: vpn_name_tag
+            AttributeType: S
+        KeySchema:
+          - AttributeName: peer_history_id
+            KeyType: HASH
+          - AttributeName: timestamp
+            KeyType: RANGE
+        GlobalSecondaryIndexes:
+          - IndexName: GSI-byIp
+            KeySchema:
+              - AttributeName: vpn_name_ip_addr
+                KeyType: HASH
+              - AttributeName: timestamp
+                KeyType: RANGE
+            Projection:
+              ProjectionType: ALL
+          - IndexName: GSI-byTag
+            KeySchema:
+              - AttributeName: vpn_name_tag
+                KeyType: HASH
+              - AttributeName: timestamp
+                KeyType: RANGE
+            Projection:
+              ProjectionType: ALL
 configValidationMode: error
 # The sections below are used for development
 plugins:

--- a/src/databases/interface.py
+++ b/src/databases/interface.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 import abc
-import typing
+from typing import Optional, TYPE_CHECKING
 
-if typing.TYPE_CHECKING:
+from models.peer_history import PeerHistoryResponseModel
+
+if TYPE_CHECKING:
     from models.peers import PeerDbModel
     from vpn_manager.vpn import VpnServer
     from vpn_manager.peers import Peer
@@ -68,4 +70,16 @@ class AbstractDatabase(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def update_connection_info(self, vpn_name: str, connection_info: ConnectionModel):
         """Update the connection info"""
+        pass
+
+    @abc.abstractmethod
+    def get_tag_history_endpoint(
+        self, vpn_name: str, tag: str, start_time: Optional[str] = None, end_time: Optional[str] = None
+    ) -> list[PeerHistoryResponseModel]:
+        pass
+
+    @abc.abstractmethod
+    def get_peer_history_endpoint(
+        self, vpn_name: str, ip_address: str, start_time: Optional[str] = None, end_time: Optional[str] = None
+    ) -> list[PeerHistoryResponseModel]:
         pass

--- a/src/models/peer_history.py
+++ b/src/models/peer_history.py
@@ -1,0 +1,7 @@
+from pydantic import Field
+
+from models.peers import PeerResponseModel
+
+
+class PeerHistoryResponseModel(PeerResponseModel):
+    timestamp: int = Field(..., description="The timestamp of when the peer history was updated.")

--- a/src/vpn_manager/__init__.py
+++ b/src/vpn_manager/__init__.py
@@ -1,10 +1,13 @@
 import ipaddress
 import codecs
+from typing import Optional
+
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from cryptography.hazmat.primitives import serialization
 import logging
 from uuid import uuid4
 from databases.interface import AbstractDatabase
+from models.peer_history import PeerHistoryResponseModel
 from vpn_manager.vpn import VpnServer
 from vpn_manager.peers import PeerList, Peer
 from models.vpn import VpnPutModel
@@ -169,3 +172,13 @@ class VpnManager:
     def delete_tag_from_peer(self, vpn_name: str, peer_ip: str, tag: str):
         """Delete a tag from an existing peer"""
         self._db_manager.delete_tag_from_peer(vpn_name, peer_ip, tag)
+
+    def get_tag_history_endpoint(
+        self, vpn_name: str, tag: str, start_time: Optional[str] = None, end_time: Optional[str] = None
+    ) -> list[PeerHistoryResponseModel]:
+        return self._db_manager.get_tag_history_endpoint(vpn_name, tag, start_time, end_time)
+
+    def get_peer_history_endpoint(
+        self, vpn_name: str, ip_address: str, start_time: Optional[str] = None, end_time: Optional[str] = None
+    ) -> list[PeerHistoryResponseModel]:
+        return self._db_manager.get_peer_history_endpoint(vpn_name, ip_address, start_time, end_time)


### PR DESCRIPTION
- Add ability to store peer history
- Add ability to query peer history
- update serverless config to initialize peer history config

Testing:
- Testing was done using a test wireguard server with one connected test peer.
- History artifacts were created and queried
<img width="1920" height="8646" alt="image" src="https://github.com/user-attachments/assets/7e0e883b-9e15-4b5c-a504-cee29e7f7917" />

