### PR TITLE
refactor: Add peers from the vpn_manager itself instead of from the PeerList

### DIFF
--- a/src/interfaces/peers.py
+++ b/src/interfaces/peers.py
@@ -101,7 +101,7 @@ def add_peer(vpn_name: str, peer: PeerRequestModel) -> PeerResponseModel:
             server_manager.add_peer(vpn, new_peer)
         except ConnectionException as ex:
             raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=ex)
-    vpn.peers.append(new_peer)
+    vpn_manager.add_peer(vpn_name, new_peer)
     vpn.calculate_available_ips()
     return new_peer.to_model()
 

--- a/src/vpn_manager/__init__.py
+++ b/src/vpn_manager/__init__.py
@@ -75,6 +75,12 @@ class VpnManager:
             _vpn.peers.clear()
             self._db_manager.delete_vpn(name)
 
+    def add_peer(self, vpn_name: str, peer: Peer):
+        """This will add the peer to the database"""
+        vpn = self.get_vpn(vpn_name)
+        self._db_manager.add_peer(vpn_name=vpn_name, peer=peer.to_db_model())
+        vpn.peers.append(peer)
+
     def get_peers_by_ip(self, vpn_name: str, ip_address: str) -> Peer | None:
         _vpn = self.get_vpn(vpn_name)
         if _vpn is None:
@@ -156,8 +162,7 @@ class VpnManager:
                     skip_peer = True
 
             if not skip_peer:
-                add_peers.append(import_peer)
-                _vpn.peers.append(import_peer)
+                self.add_peer(vpn_name, import_peer)
         _vpn.calculate_available_ips()
 
         return add_peers

--- a/src/vpn_manager/peers.py
+++ b/src/vpn_manager/peers.py
@@ -94,18 +94,7 @@ class PeerList(list):
             super().append(peer)
 
     def append(self, value: Peer):
-        self.db_interface.add_peer(vpn_name=self.vpn_name, peer=value.to_db_model())
         super().append(value)
-
-    def remove(self, value: Peer):
-        self.db_interface.delete_peer(vpn_name=self.vpn_name, peer=value.to_db_model())
-        super().remove(value)
-
-    def clear(self):
-        """Clear the peer list and remove all peers from the database."""
-        for peer in self:
-            self.db_interface.delete_peer(vpn_name=self.vpn_name, peer=peer.to_db_model())
-        super().clear()
 
     def to_model(self) -> list[PeerResponseModel]:
         """Convert the peer list to a list of PeerResponseModel."""


### PR DESCRIPTION
This is a step in part of a greater refactor to get rid of the ```VpnServer``` and ```Peer``` objects from the vpn_manager.