### PR TITLE
Add authentication support for AWS Cognito

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,7 +75,7 @@ def main(
         None,
         "--cognito-redirect-uri",
         help=(
-            "The redirect URI for Cognito Login Page, required if using Cognito authentication. "
+            "The redirect URI for Cognito Login Page. This must match the one set in the Cognito App Client settings. "
             "Defaults to http://<uvicorn-host>:<uvicorn-port>/oauth2-redirect"
         ),
     ),

--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,7 @@ coloredlogs.install()
 
 typer_app = typer.Typer()
 
+
 def setup_app_routes(app: WireguardManagerAPI) -> None:
     for router in ROUTERS:
         app.include_router(router)

--- a/src/app.py
+++ b/src/app.py
@@ -1,33 +1,27 @@
-import sys
-import signal
-import uvicorn
 import logging
+import signal
+import sys
+from http import HTTPStatus
+
 import coloredlogs
 import typer
-from fastapi import FastAPI, Response
-from http import HTTPStatus
-from interfaces.vpn import vpn_router
-from interfaces.peers import peer_router
+import uvicorn
+from fastapi import Response
+
+from auth import AuthProvider, CognitoAuthWireguardAPI, WireguardAPI
 from databases.dynamodb import DynamoDb
+from interfaces.peers import peer_router
+from interfaces.vpn import vpn_router
 from vpn_manager import VpnManager
 
+ROUTERS = [vpn_router, peer_router]
 
 log = logging.getLogger(__name__)
+coloredlogs.install()
+
 typer_app = typer.Typer()
 
-coloredlogs.install()
-app = FastAPI(
-    openapi_url="/spec",
-    title="Wireguard Manager",
-    description="API for managing wireguard clients",
-)
-routers = [vpn_router, peer_router]
-for router in routers:
-    app.include_router(router)
 
-
-@app.get("/", tags=["wg-manager"])
-@app.get("/health", tags=["wg-manager"])
 def health() -> Response:
     return Response(status_code=HTTPStatus.OK)
 
@@ -57,15 +51,24 @@ def main(
         "--environment",
         help="Use this to configure which environment the service should use. This is used to determine which database to use.",
     ),
-    ssl_keyfile: str = typer.Option(
+    ssl_keyfile: str = typer.Option(None, "--ssl-keyfile", help="Path to your private key file for SSL"),
+    ssl_certfile: str = typer.Option(None, "--ssl-certfile", help="Path to your SSL certificate file"),
+    auth_provider: AuthProvider = typer.Option(AuthProvider.NONE, "--auth", help="The authentication provider to use"),
+    cognito_client_id: str = typer.Option(
         None,
-        "--ssl-keyfile",
-        help="Path to your private key file for SSL",
+        "--cognito-client-id",
+        help="The Client ID corresponding to the app client in Cognito, required if using Cognito authentication.",
     ),
-    ssl_certfile: str = typer.Option(
+    cognito_domain: str = typer.Option(
+        None, "--cognito-domain", help="The Cognito domain, required if using Cognito authentication."
+    ),
+    cognito_redirect_uri: str = typer.Option(
         None,
-        "--ssl-certfile",
-        help="Path to your SSL certificate file",
+        "--cognito-redirect-uri",
+        help=(
+            "The redirect URI for Cognito Login Page, required if using Cognito authentication. "
+            "Defaults to http://<uvicorn-host>:<uvicorn-port>/oauth2-redirect"
+        ),
     ),
 ):
     """
@@ -79,19 +82,42 @@ def main(
 
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 
-    dynamo_db = DynamoDb(
-        environment=environment,
-        dynamodb_endpoint_url=dynamodb_endpoint,
-        aws_region=aws_region,
-    )
+    match auth_provider:
+        case AuthProvider.COGNITO:
+            print("Using Cognito authentication.")
+            if not cognito_client_id or not cognito_domain:
+                print(
+                    "ERROR: Parameters cognito_client_id and cognito_domain are required when using Cognito authentication."
+                )
+                sys.exit(1)
+            if not cognito_redirect_uri:
+                cognito_redirect_uri = f"http://{uvicorn_host}:{uvicorn_port}/oauth2-redirect"
+            app = CognitoAuthWireguardAPI(
+                client_id=cognito_client_id, swagger_redirect_uri=cognito_redirect_uri, cognito_domain=cognito_domain
+            )
+        case AuthProvider.NONE:
+            print("No authentication configured.")
+            app = WireguardAPI()
+        case _:
+            raise ValueError(f"Unsupported auth provider: {auth_provider}")
+
+    for router in ROUTERS:
+        app.include_router(router)
+
+    # Add any root level routes here
+    app.add_api_route("/", health, methods=["GET"], tags=["wg-manager"])
+    app.add_api_route("/health", health, methods=["GET"], tags=["wg-manager"])
+
+    dynamo_db = DynamoDb(environment=environment, dynamodb_endpoint_url=dynamodb_endpoint, aws_region=aws_region)
     vpn_manager = VpnManager(db_manager=dynamo_db)
 
-    for _router in routers:
+    for _router in ROUTERS:
         _router.vpn_manager = vpn_manager
 
     try:
+        print("Starting uvicorn")
         uvicorn.run(
-            "__main__:app",
+            app,
             host=uvicorn_host,
             port=uvicorn_port,
             log_config=None,

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
-from .cognito import CognitoAuthWireguardAPI
-from .unauthenticated import WireguardAPI
+from .cognito import CognitoAuthWireguardManagerAPI
+from .unauthenticated import WireguardManagerAPI
 
 
 class AuthProvider(str, Enum):

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+from .cognito import CognitoAuthWireguardAPI
+from .unauthenticated import WireguardAPI
+
+
+class AuthProvider(str, Enum):
+    NONE = "none"
+    COGNITO = "cognito"

--- a/src/auth/cognito.py
+++ b/src/auth/cognito.py
@@ -1,0 +1,32 @@
+from fastapi import Depends
+from fastapi.security import OAuth2AuthorizationCodeBearer
+
+from auth.unauthenticated import WireguardAPI
+
+
+class CognitoAuthWireguardAPI(WireguardAPI):
+    """
+    AWS Cognito authentication for Wireguard API.
+    """
+
+    def __init__(self, client_id: str, swagger_redirect_uri: str, cognito_domain: str):
+        """
+        Instantiate the FastAPI app using AWS Cognito for
+        authentication. Includes support for user login on the Swagger
+        UI via PKCE.
+        """
+        oauth2_scheme = OAuth2AuthorizationCodeBearer(
+            authorizationUrl=f"{cognito_domain}/login", tokenUrl=f"{cognito_domain}/oauth2/token"
+        )
+
+        super().__init__(
+            dependencies=[Depends(oauth2_scheme)],
+            swagger_ui_oauth2_redirect_url="/oauth2-redirect",
+            swagger_ui_init_oauth={
+                "clientId": client_id,
+                "appName": "Wireguard Manager",
+                "scopes": "openid",
+                "usePkceWithAuthorizationCodeGrant": True,
+                "redirectUri": swagger_redirect_uri,
+            },
+        )

--- a/src/auth/cognito.py
+++ b/src/auth/cognito.py
@@ -1,10 +1,10 @@
 from fastapi import Depends
 from fastapi.security import OAuth2AuthorizationCodeBearer
 
-from auth.unauthenticated import WireguardAPI
+from auth.unauthenticated import WireguardManagerAPI
 
 
-class CognitoAuthWireguardAPI(WireguardAPI):
+class CognitoAuthWireguardManagerAPI(WireguardManagerAPI):
     """
     AWS Cognito authentication for Wireguard API.
     """

--- a/src/auth/unauthenticated.py
+++ b/src/auth/unauthenticated.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+
+
+class WireguardAPI(FastAPI):
+
+    def __init__(self, **kwargs):
+        """
+        Instantiate the FastAPI app, passing in any kwargs to the
+        FastAPI constructor.
+        """
+        super().__init__(
+            openapi_url="/spec", title="Wireguard Manager", description="API for managing wireguard clients", **kwargs
+        )

--- a/src/auth/unauthenticated.py
+++ b/src/auth/unauthenticated.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 
 
-class WireguardAPI(FastAPI):
+class WireguardManagerAPI(FastAPI):
 
     def __init__(self, **kwargs):
         """

--- a/src/tests/test_peer_interface.py
+++ b/src/tests/test_peer_interface.py
@@ -1,23 +1,26 @@
+import datetime
 import urllib.parse
 from http import HTTPStatus
-from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
-import pytest
-from pydantic import SecretStr
-import datetime
+from unittest.mock import MagicMock, patch
 
-from app import app, vpn_router
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from app import setup_app_routes, vpn_router
+from auth import WireguardManagerAPI
+from interfaces.peers import peer_router
+from models.connection import ConnectionModel, ConnectionType
 from models.peer_history import PeerHistoryResponseModel
+from models.peers import PeerRequestModel, PeerResponseModel
 from models.ssh import SshConnectionModel
 from models.ssm import SsmConnectionModel
-from models.vpn import VpnPutModel, WireguardModel, VpnModel
-from models.connection import ConnectionModel, ConnectionType
+from models.vpn import VpnModel, VpnPutModel, WireguardModel
 from models.wg_server import WgServerModel, WgServerPeerModel
-from models.peers import PeerRequestModel, PeerResponseModel
-from interfaces.peers import peer_router
 
-
+app = WireguardManagerAPI()
 client = TestClient(app)
+setup_app_routes(app)
 
 test_parameters = [
     VpnModel(

--- a/src/tests/test_vpn_interface.py
+++ b/src/tests/test_vpn_interface.py
@@ -1,22 +1,27 @@
 import urllib.parse
 from copy import deepcopy
 from http import HTTPStatus
+from unittest.mock import MagicMock, patch
 
+import pytest
 from botocore.exceptions import ClientError
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
-import pytest
 
-from app import app, vpn_router
+from app import setup_app_routes, vpn_router
+from auth import WireguardManagerAPI
+from models.connection import ConnectionModel, ConnectionType
 from models.ssh import SshConnectionModel
 from models.ssm import SsmConnectionModel
-from models.vpn import VpnPutModel, WireguardModel, VpnModel
-from models.connection import ConnectionModel, ConnectionType
+from models.vpn import VpnModel, VpnPutModel, WireguardModel
 from models.wg_server import WgServerModel
 
 """
 ALL THE TESTS HERE ARE RUN SUCCESSIVELY.  IF THE FIRST TEST FAILS, THE REST WILL PROBABLY FAIL TOO.
 """
+
+app = WireguardManagerAPI()
+client = TestClient(app)
+setup_app_routes(app)
 
 client = TestClient(app)
 


### PR DESCRIPTION
Change:
+ adds support to optionally use AWS Cognito as an authentication provider
  + Also supports OAuth PKCE flow to authenticate with user credentials using an external login page
+ default auth behaviour is unchanged, which is no authentication required
+ adjusted how the FastAPI class is instantiated to support alternative instantiation patterns
+ adjusted how tests access the FastAPI `app` object to support the new changes
+ sorted imports using isort on touched files

Testing:
+ Manually tested access to the unauthenticated API
+ Manually tested access to the APIs using bearer token
+ Manually tested access to the APIs using the "Authorize" button and login on the Swagger API page.

Demo of user login:
https://github.com/user-attachments/assets/603c75f5-f908-4829-b15a-d9fb5bcb97ea


