### PR TITLE
parse user into request state from auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.10.4-slim as pip-packages
-ENV HDF5_DIR /usr/include/hdf5
+FROM python:3.10-slim
+ENV HDF5_DIR=/usr/include/hdf5
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_NO_CACHE_DIR=False
 
@@ -11,5 +11,4 @@ ADD . /opt/wireguard-manager/.
 EXPOSE 6000
 
 WORKDIR /opt/wireguard-manager
-ENV PYTHONPATH /opt/blah
 CMD ["python3", "-u", "/opt/wireguard-manager/src/app.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,12 @@ paramiko==4.0.0
 psycopg2-binary==2.9.3
 boto3==1.28.52
 cryptography==45.0.2
+pyjwt==2.10.1
+httpx==0.28.1
 
 # These packages are used for testing
 pytest==8.4.1
 pytest-cov==6.2.1
 parse==1.20.2
-httpx==0.28.1
 moto==5.1.1
 pytest_mock==3.14.1

--- a/src/app.py
+++ b/src/app.py
@@ -155,7 +155,6 @@ def main(
         raise RuntimeError(msg) from ex
     finally:
         exit_application()
-    log.info("Main thread exiting")
 
 
 if __name__ == "__main__":

--- a/src/app.py
+++ b/src/app.py
@@ -92,6 +92,12 @@ def main(
         ),
         envvar="COGNITO_REDIRECT_URI",
     ),
+    cognito_jwks_url: str = typer.Option(
+        None,
+        "--cognito-jwks-url",
+        help="The Token signing key URL or JSON Web Key Set (JWKS) URL for Cognito, required if using Cognito authentication.",
+        envvar="COGNITO_JWKS_URL",
+    ),
 ):
     """
     Set network monitoring to true for all sites in environment.
@@ -106,19 +112,23 @@ def main(
 
     match auth_provider:
         case AuthProvider.COGNITO:
-            print("Using Cognito authentication.")
-            if not cognito_client_id or not cognito_domain:
-                print(
-                    "ERROR: Parameters cognito_client_id and cognito_domain are required when using Cognito authentication."
+            log.info("Using Cognito authentication.")
+            if not cognito_client_id or not cognito_domain or not cognito_jwks_url:
+                log.error(
+                    "ERROR: Parameters cognito_client_id, cognito_domain, and cognito_jwks_url are required when using "
+                    "Cognito authentication."
                 )
                 sys.exit(1)
             if not cognito_redirect_uri:
                 cognito_redirect_uri = f"http://{uvicorn_host}:{uvicorn_port}/oauth2-redirect"
             app = CognitoAuthWireguardManagerAPI(
-                client_id=cognito_client_id, swagger_redirect_uri=cognito_redirect_uri, cognito_domain=cognito_domain
+                client_id=cognito_client_id,
+                swagger_redirect_uri=cognito_redirect_uri,
+                cognito_domain=cognito_domain,
+                jwks_url=cognito_jwks_url,
             )
         case AuthProvider.NONE:
-            print("No authentication configured.")
+            log.info("No authentication configured.")
             app = WireguardManagerAPI()
         case _:
             raise ValueError(f"Unsupported auth provider: {auth_provider}")
@@ -129,9 +139,8 @@ def main(
 
     for _router in ROUTERS:
         _router.vpn_manager = vpn_manager
-
     try:
-        print("Starting uvicorn")
+        log.info("Starting uvicorn")
         uvicorn.run(
             app,
             host=uvicorn_host,
@@ -146,6 +155,7 @@ def main(
         raise RuntimeError(msg) from ex
     finally:
         exit_application()
+    log.info("Main thread exiting")
 
 
 if __name__ == "__main__":

--- a/src/auth/cognito.py
+++ b/src/auth/cognito.py
@@ -1,7 +1,46 @@
-from fastapi import Depends
+import asyncio
+import logging
+import time
+from contextlib import asynccontextmanager
+from typing import Optional
+
+import httpx
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2AuthorizationCodeBearer
+from jwt import decode, get_unverified_header
+from jwt.algorithms import RSAAlgorithm
+from pydantic import BaseModel
 
 from auth.unauthenticated import WireguardManagerAPI
+
+log = logging.getLogger(__name__)
+
+SUPPORTED_JWT_ALGORITHMS = ["RS256"]
+JWKS_FETCH_INTERVAL = 3600  # seconds
+
+
+class CognitoJWT(BaseModel):
+    """
+    Schema for the JWT returned by AWS Cognito. The fields vary slightly
+    between user and M2M tokens, so those fields are optional.
+    """
+
+    sub: str
+    iss: str
+    version: int
+    client_id: str
+    token_use: str
+    scope: str
+    auth_time: int
+    exp: int
+    iat: int
+    jti: str
+    origin_jti: Optional[str] = None
+    username: Optional[str] = None
+    event_id: Optional[str] = None
+
+    class Config:
+        extra = "allow"
 
 
 class CognitoAuthWireguardManagerAPI(WireguardManagerAPI):
@@ -9,24 +48,125 @@ class CognitoAuthWireguardManagerAPI(WireguardManagerAPI):
     AWS Cognito authentication for Wireguard API.
     """
 
-    def __init__(self, client_id: str, swagger_redirect_uri: str, cognito_domain: str):
+    def __init__(self, client_id: str, swagger_redirect_uri: str, cognito_domain: str, jwks_url: str):
         """
         Instantiate the FastAPI app using AWS Cognito for
         authentication. Includes support for user login on the Swagger
         UI via PKCE.
         """
+        self._key_map = {}
+        self._jwks_url = jwks_url
         oauth2_scheme = OAuth2AuthorizationCodeBearer(
             authorizationUrl=f"{cognito_domain}/login", tokenUrl=f"{cognito_domain}/oauth2/token"
         )
 
+        if not jwks_url.endswith("/.well-known/jwks.json"):
+            raise ValueError("The jwks_url must be the full URL to the JWKS, ending in /.well-known/jwks.json")
+        issuer_url = jwks_url.replace("/.well-known/jwks.json", "")
+
+        # Fetch the JWKS and start a background task to refresh it periodically in case keys are rotated
+        self._fetch_jwks(jwks_url)
+
+        # Create a dependency to verify the token on each request using the cached keys from the key map
+        async def verify_token(request: Request, token: str = Depends(oauth2_scheme)):
+            # Decode the header to identify the key ID (kid) used to sign the token
+            try:
+                header = get_unverified_header(token)
+                key_id = header["kid"]
+            except Exception as e:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail=f"Invalid token: {e}",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
+            issuer_public_signing_key = self._key_map.get(key_id, None)
+            if issuer_public_signing_key is None:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid token: Unknown 'kid'",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
+            # Verify the token signature and claims
+            decoded_token = decode(
+                token, key=issuer_public_signing_key, algorithms=SUPPORTED_JWT_ALGORITHMS, issuer=issuer_url
+            )
+            token_payload = CognitoJWT(**decoded_token)
+
+            # Check token expiration
+            if token_payload.exp < time.time():
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid token: Token has expired",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            # Pass in the user information in the request state for use in endpoints
+            request.state.user = token_payload.sub
+
         super().__init__(
-            dependencies=[Depends(oauth2_scheme)],
+            dependencies=[Depends(verify_token)],
             swagger_ui_oauth2_redirect_url="/oauth2-redirect",
             swagger_ui_init_oauth={
                 "clientId": client_id,
                 "appName": "Wireguard Manager",
-                "scopes": "openid",
+                "scopes": "openid email",
                 "usePkceWithAuthorizationCodeGrant": True,
                 "redirectUri": swagger_redirect_uri,
             },
+            lifespan=self._lifespan,
         )
+
+    def _fetch_jwks(self, jwks_url: str):
+        """
+        Fetch the JSON Web Key Set (JWKS) from the specified URL.
+        """
+        log.info(f"Fetching JWKS from {jwks_url}")
+        try:
+            with httpx.Client() as client:
+                response = client.get(jwks_url)
+                response.raise_for_status()
+                jwks_json = response.json()
+        except Exception as e:
+            raise ValueError(f"Failed to fetch JWKS from {jwks_url}") from e
+
+        jwks = {key["kid"]: key for key in jwks_json["keys"]}
+
+        key_map = {}
+        for key in jwks.values():
+            if key["alg"] == "RS256":  # Cognito only appears to use RSA256 keys currently
+                key_map[key["kid"]] = RSAAlgorithm.from_jwk(key)
+            else:
+                raise ValueError(f"Unsupported key type/algorithm in JWKS. Type: {key['kty']}, Algorithm: {key['alg']}")
+        self._key_map = key_map
+        log.info(f"Fetched {len(key_map)} keys from JWKS")
+
+    async def _fetch_jwks_loop(self, jwks_url: str, stop_event: asyncio.Event):
+        """
+        Background task to periodically fetch the JWKS to refresh keys
+        in case of rotation. If the app is shutting down, the task
+        will exit immediately.
+        """
+        while not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=JWKS_FETCH_INTERVAL)
+            except asyncio.TimeoutError:
+                self._fetch_jwks(jwks_url)
+
+    @asynccontextmanager
+    async def _lifespan(self, _):
+        """
+        This is the FastAPI lifespan handler. Start the background task
+        to periodically refresh the JWKS on startup, and stop it on
+        shutdown.
+
+        The FastAPI object itself is passed as the first argument, it is
+        unused.
+        """
+        stop_event = asyncio.Event()
+        task = asyncio.create_task(self._fetch_jwks_loop(self._jwks_url, stop_event))
+        try:
+            yield
+        finally:
+            stop_event.set()
+            await task

--- a/src/auth/cognito.py
+++ b/src/auth/cognito.py
@@ -89,9 +89,16 @@ class CognitoAuthWireguardManagerAPI(WireguardManagerAPI):
                 )
 
             # Verify the token signature and claims
-            decoded_token = decode(
-                token, key=issuer_public_signing_key, algorithms=SUPPORTED_JWT_ALGORITHMS, issuer=issuer_url
-            )
+            try:
+                decoded_token = decode(
+                    token, key=issuer_public_signing_key, algorithms=SUPPORTED_JWT_ALGORITHMS, issuer=issuer_url
+                )
+            except Exception as e:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail=f"Invalid token: {e}",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
             token_payload = CognitoJWT(**decoded_token)
 
             # Check token expiration

--- a/src/auth/unauthenticated.py
+++ b/src/auth/unauthenticated.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Request
 
 
 class WireguardManagerAPI(FastAPI):
@@ -8,6 +8,21 @@ class WireguardManagerAPI(FastAPI):
         Instantiate the FastAPI app, passing in any kwargs to the
         FastAPI constructor.
         """
+        if "dependencies" in kwargs:
+            dependencies = kwargs.pop("dependencies")
+            dependencies.append(Depends(self._set_user_state))
+        else:
+            dependencies = [Depends(self._set_user_state)]
+
         super().__init__(
-            openapi_url="/spec", title="Wireguard Manager", description="API for managing wireguard clients", **kwargs
+            openapi_url="/spec",
+            title="Wireguard Manager",
+            description="API for managing wireguard clients",
+            dependencies=dependencies,
+            **kwargs
         )
+
+    def _set_user_state(self, request: Request):
+        """Set the user state to unauthenticated if not already set."""
+        if not hasattr(request.state, "user"):
+            request.state.user = "unauthenticated"


### PR DESCRIPTION
## Auth
+ Unauthenticated
  + Add a dependency so that if no user string is present on the `request.state` it defaults to 'unauthenticated'
+ Cognito
  + Pull in the well known signing keys on startup
  + Add a background task into the fast API lifespan to refresh the signing keys periodically, since they can be rotated
  + Decode the provided token on each request and parse the user/app id into the `request.state` so it becomes globally accessible to any endpoint that adds `request: fastapi.Request` as an argument to the function call.
    + e.g. Updating the `get_all_vpns` endpoint to log the user would look like this.
      ```python3
      @vpn_router.get("/vpn", tags=["vpn"], response_model=list[VpnResponseModel])
      def get_all_vpns(request: Request, hide_secrets: bool = True) -> list[VpnResponseModel]:
          """Get all the VPN servers managed by this service."""
          log.info("Received request from user '%s'", request.state.user)
          # ...
      ```
    + Note that no update have been made to actually consume this data in this PR, it just makes it available.
  + Add in reading the URL for the JSON Web Key Set (JWKS) URL for the used Cognito User Pool.

## Cleanup
+ Docker file:
  + Lock to minor version instead of the patch version so new builds pull in security fixes
  + Adjust ENV line for consistency
  + Remove unused ENV line for `/opt/blah`
