### PR TITLE
Handle unset or zero persistent keep-alive

### DIFF
--- a/src/server_manager/__init__.py
+++ b/src/server_manager/__init__.py
@@ -72,7 +72,9 @@ def extract_wg_server_config(wg_interface, wg_config: list[str]) -> Optional[WgS
             latest_handshake=int(latest_handshake),
             transfer_rx=int(transfer_rx),
             transfer_tx=int(transfer_tx),
-            persistent_keepalive=int(persistent_keepalive),
+            persistent_keepalive=(
+                int(persistent_keepalive) if str(persistent_keepalive).strip().lower() not in {"", "off"} else 0
+            ),
         )
         vpn_model.peers.append(peer)
 


### PR DESCRIPTION
Change:
- Handle edge case values from the `wg show {wg_interface} dump` command that we're using to gather information from the wireguard server, which can be an empty string or an `off` string for the persistent_keepalive setting. From the docs, the wiregurd server is equating "off" and 0 as the same thing, so we should be safe to make that same equality.  Checked the other values that we're casting to int and the interfaces look to be strictly integer strings there, so no other changes are necessary.

From the docs:
       •      PersistentKeepalive — a seconds interval, between 1 and 65535 inclusive, of how often to  send  an  au‐
              thenticated  empty  packet  to  the  peer for the purpose of keeping a stateful firewall or NAT mapping
              valid persistently. For example, if the interface very rarely sends traffic, but it  might  at  anytime
              receive traffic from a peer, and it is behind NAT, the interface might benefit from having a persistent
              keepalive interval of 25 seconds. If set to 0 or "off", this option is disabled. By default or when un‐
              specified, this option is off. Most users will not need this. Optional.

Issue:
While trying to import an existing wireguard server config onto the wireguard-manager, any peer with a persistent_keepalive value which is explicitly 0 or unset returns an "off", which the scraping has a hard time casting to int, as seen here.
<img width="1801" height="304" alt="image" src="https://github.com/user-attachments/assets/cfbdfdc9-3711-4125-9cec-47927d7ea8e9" />

